### PR TITLE
Fix semantic calculation error; timestamp improvement

### DIFF
--- a/pds-queries/2022-stewardship/nightly-reports.py
+++ b/pds-queries/2022-stewardship/nightly-reports.py
@@ -704,6 +704,9 @@ def pledge_comparison_report(google, jotform_this_year, jotform_last_year, log):
             # If the family is recorded as having a pledge of 0 OR 1 last year,
             # then they did not have a pledge last year.
             elif previous_pledge == 0 or previous_pledge == 1:
+                # Set their previous pledge to zero to accurately reflect how
+                # much they *actually* pledged last year.
+                previous_pledge = 0
                 if current_pledge == 0:
                     category = "No pledge both years"
                 # If the family didn't pledge last year, but pledged this year,


### PR DESCRIPTION
If someone had a $1 "pledge" last year, they didn't actually have a pledge, but in the code, the dollar impact was calculated  as if they *did* have a pledge and it was $1 dollar. Instead, we're now setting their previous pledge to $0 so the dollar impact is properly calculated.

Also, I'm marking this as a draft because I want to add another commit with my timestamp changes, but can't quite make them right now. (Hopefully in an hour or two.)